### PR TITLE
LPD-54424 Support folder navigation and actions in Spaces

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -47,6 +47,7 @@ import com.liferay.object.rest.context.path.RESTContextPathResolver;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -129,6 +130,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		ListTypeLocalService listTypeLocalService,
 		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryFolderLocalService objectEntryFolderLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryService objectEntryService,
 		ObjectFieldLocalService objectFieldLocalService,
@@ -161,6 +163,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_listTypeLocalService = listTypeLocalService;
 		_objectActionLocalService = objectActionLocalService;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryFolderLocalService = objectEntryFolderLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryService = objectEntryService;
 		_objectFieldLocalService = objectFieldLocalService;
@@ -297,8 +300,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					new ObjectEntryModelDocumentContributor(
 						_accountEntryOrganizationRelLocalService,
 						objectDefinition.getClassName(),
-						_objectDefinitionLocalService, _objectEntryLocalService,
-						_objectFieldLocalService, _objectFolderLocalService),
+						_objectDefinitionLocalService,
+						_objectEntryFolderLocalService,
+						_objectEntryLocalService, _objectFieldLocalService,
+						_objectFolderLocalService),
 					HashMapDictionaryBuilder.<String, Object>put(
 						"indexer.class.name", objectDefinition.getClassName()
 					).build()),
@@ -615,6 +620,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectDefinitionTreeFactory _objectDefinitionTreeFactory;
+	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryService _objectEntryService;
 	private final ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryDocumentContributor.java
@@ -5,23 +5,14 @@
 
 package com.liferay.object.internal.search.spi.model.index.contributor;
 
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.petra.string.CharPool;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -53,93 +44,10 @@ public class ObjectEntryDocumentContributor
 		field.setValue(objectDefinition.getClassName());
 
 		document.add(field);
-
-		if (FeatureFlagManagerUtil.isEnabled(
-				objectEntry.getCompanyId(), "LPD-17564")) {
-
-			_contributeObjectEntryFolderAttributes(
-				document, objectEntry.getObjectEntryFolderId());
-		}
-	}
-
-	private void _contributeObjectEntryFolderAttributes(
-		Document document, long objectEntryFolderId) {
-
-		document.addKeyword(Field.FOLDER_ID, objectEntryFolderId);
-
-		ObjectEntryFolder objectEntryFolder =
-			_objectEntryFolderLocalService.fetchObjectEntryFolder(
-				objectEntryFolderId);
-
-		if (objectEntryFolder == null) {
-			document.addKeyword("cms_section", "none");
-		}
-		else {
-			document.addKeyword("cms_kind", "object");
-
-			ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
-				objectEntryFolder);
-
-			document.addKeyword(
-				"cms_root",
-				rootObjectEntryFolder.getObjectEntryFolderId() ==
-					objectEntryFolderId);
-			document.addKeyword(
-				"cms_section",
-				_getCMSSection(
-					rootObjectEntryFolder.getExternalReferenceCode()));
-		}
-	}
-
-	private String _getCMSSection(String externalReferenceCode) {
-		if (externalReferenceCode.equals(
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
-
-			return "contents";
-		}
-
-		if (externalReferenceCode.equals(
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
-
-			return "files";
-		}
-
-		return "none";
-	}
-
-	private ObjectEntryFolder _getRootObjectEntryFolder(
-		ObjectEntryFolder objectEntryFolder) {
-
-		if (objectEntryFolder == null) {
-			return null;
-		}
-
-		if (Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) ||
-			Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
-
-			return objectEntryFolder;
-		}
-
-		String[] parts = StringUtil.split(
-			objectEntryFolder.getTreePath(), CharPool.SLASH);
-
-		if (parts.length <= 2) {
-			return null;
-		}
-
-		return _objectEntryFolderLocalService.fetchObjectEntryFolder(
-			GetterUtil.getLong(parts[1]));
 	}
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryDocumentContributor.java
@@ -5,15 +5,23 @@
 
 package com.liferay.object.internal.search.spi.model.index.contributor;
 
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -49,13 +57,89 @@ public class ObjectEntryDocumentContributor
 		if (FeatureFlagManagerUtil.isEnabled(
 				objectEntry.getCompanyId(), "LPD-17564")) {
 
-			document.addKeyword(
-				Field.FOLDER_ID, objectEntry.getObjectEntryFolderId());
+			_contributeObjectEntryFolderAttributes(
+				document, objectEntry.getObjectEntryFolderId());
 		}
+	}
+
+	private void _contributeObjectEntryFolderAttributes(
+		Document document, long objectEntryFolderId) {
+
+		document.addKeyword(Field.FOLDER_ID, objectEntryFolderId);
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(
+				objectEntryFolderId);
+
+		if (objectEntryFolder == null) {
+			document.addKeyword("cms_section", "none");
+		}
+		else {
+			document.addKeyword("cms_kind", "object");
+
+			ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
+				objectEntryFolder);
+
+			document.addKeyword(
+				"cms_root",
+				rootObjectEntryFolder.getObjectEntryFolderId() ==
+					objectEntryFolderId);
+			document.addKeyword(
+				"cms_section",
+				_getCMSSection(
+					rootObjectEntryFolder.getExternalReferenceCode()));
+		}
+	}
+
+	private String _getCMSSection(String externalReferenceCode) {
+		if (externalReferenceCode.equals(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
+
+			return "contents";
+		}
+
+		if (externalReferenceCode.equals(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			return "files";
+		}
+
+		return "none";
+	}
+
+	private ObjectEntryFolder _getRootObjectEntryFolder(
+		ObjectEntryFolder objectEntryFolder) {
+
+		if (objectEntryFolder == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) ||
+			Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			return objectEntryFolder;
+		}
+
+		String[] parts = StringUtil.split(
+			objectEntryFolder.getTreePath(), CharPool.SLASH);
+
+		if (parts.length <= 2) {
+			return null;
+		}
+
+		return _objectEntryFolderLocalService.fetchObjectEntryFolder(
+			GetterUtil.getLong(parts[1]));
 	}
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -43,11 +43,15 @@ public class ObjectEntryFolderModelDocumentContributor
 
 		document.addKeyword(Field.TREE_PATH, parts);
 
-		document.addKeyword("cms_kind", "folder");
+		String cmsSection = _getCMSSection(parts);
 
-		document.addKeyword("cms_section", _getCMSSection(parts));
+		if (cmsSection != null) {
+			document.addKeyword("cms_kind", "folder");
 
-		document.addKeyword("cms_root", parts.length == 3);
+			document.addKeyword("cms_root", parts.length == 3);
+
+			document.addKeyword("cms_section", cmsSection);
+		}
 
 		document.addLocalizedKeyword(
 			"localized_label", objectEntryFolder.getLabelMap(), true, true);
@@ -55,7 +59,7 @@ public class ObjectEntryFolderModelDocumentContributor
 
 	private String _getCMSSection(String[] parts) {
 		if (parts.length <= 2) {
-			return "none";
+			return null;
 		}
 
 		ObjectEntryFolder objectEntryFolder =
@@ -63,7 +67,7 @@ public class ObjectEntryFolderModelDocumentContributor
 				GetterUtil.getLong(parts[1]));
 
 		if (objectEntryFolder == null) {
-			return "none";
+			return null;
 		}
 
 		String externalReferenceCode =
@@ -81,7 +85,7 @@ public class ObjectEntryFolderModelDocumentContributor
 			return "files";
 		}
 
-		return "none";
+		return null;
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -42,7 +42,12 @@ public class ObjectEntryFolderModelDocumentContributor
 			objectEntryFolder.getTreePath(), CharPool.SLASH);
 
 		document.addKeyword(Field.TREE_PATH, parts);
+
+		document.addKeyword("cms_kind", "folder");
+
 		document.addKeyword("cms_section", _getCMSSection(parts));
+
+		document.addKeyword("cms_root", parts.length == 3);
 
 		document.addLocalizedKeyword(
 			"localized_label", objectEntryFolder.getLabelMap(), true, true);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -376,23 +376,27 @@ public class ObjectEntryModelDocumentContributor
 				objectEntryFolderId);
 
 		if (objectEntryFolder == null) {
-			document.addKeyword("cms_section", "none");
+			return;
 		}
-		else {
-			document.addKeyword("cms_kind", "object");
 
-			ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
-				objectEntryFolder);
+		ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
+			objectEntryFolder);
 
-			document.addKeyword(
-				"cms_root",
-				rootObjectEntryFolder.getObjectEntryFolderId() ==
-					objectEntryFolderId);
-			document.addKeyword(
-				"cms_section",
-				_getCMSSection(
-					rootObjectEntryFolder.getExternalReferenceCode()));
+		String cmsSection = _getCMSSection(
+			rootObjectEntryFolder.getExternalReferenceCode());
+
+		if (cmsSection == null) {
+			return;
 		}
+
+		document.addKeyword("cms_kind", "object");
+
+		document.addKeyword(
+			"cms_root",
+			rootObjectEntryFolder.getObjectEntryFolderId() ==
+				objectEntryFolderId);
+
+		document.addKeyword("cms_section", cmsSection);
 	}
 
 	private String _getCMSSection(String externalReferenceCode) {
@@ -408,7 +412,7 @@ public class ObjectEntryModelDocumentContributor
 			return "files";
 		}
 
-		return "none";
+		return null;
 	}
 
 	private String _getDateString(Object value) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -7,20 +7,25 @@ package com.liferay.object.internal.search.spi.model.index.contributor;
 
 import com.liferay.account.model.AccountEntryOrganizationRel;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
@@ -29,6 +34,7 @@ import com.liferay.portal.kernel.search.FieldArray;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -59,6 +65,7 @@ public class ObjectEntryModelDocumentContributor
 			accountEntryOrganizationRelLocalService,
 		String className,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryFolderLocalService objectEntryFolderLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectFolderLocalService objectFolderLocalService) {
@@ -67,6 +74,7 @@ public class ObjectEntryModelDocumentContributor
 			accountEntryOrganizationRelLocalService;
 		_className = className;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryFolderLocalService = objectEntryFolderLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectFieldLocalService = objectFieldLocalService;
 		_objectFolderLocalService = objectFolderLocalService;
@@ -349,10 +357,90 @@ public class ObjectEntryModelDocumentContributor
 		document.addKeyword(
 			"objectFolderExternalReferenceCode",
 			objectFolder.getExternalReferenceCode(), true);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				objectEntry.getCompanyId(), "LPD-17564")) {
+
+			_contributeObjectEntryFolderAttributes(
+				document, objectEntry.getObjectEntryFolderId());
+		}
+	}
+
+	private void _contributeObjectEntryFolderAttributes(
+		Document document, long objectEntryFolderId) {
+
+		document.addKeyword(Field.FOLDER_ID, objectEntryFolderId);
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(
+				objectEntryFolderId);
+
+		if (objectEntryFolder == null) {
+			document.addKeyword("cms_section", "none");
+		}
+		else {
+			document.addKeyword("cms_kind", "object");
+
+			ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
+				objectEntryFolder);
+
+			document.addKeyword(
+				"cms_root",
+				rootObjectEntryFolder.getObjectEntryFolderId() ==
+					objectEntryFolderId);
+			document.addKeyword(
+				"cms_section",
+				_getCMSSection(
+					rootObjectEntryFolder.getExternalReferenceCode()));
+		}
+	}
+
+	private String _getCMSSection(String externalReferenceCode) {
+		if (externalReferenceCode.equals(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
+
+			return "contents";
+		}
+
+		if (externalReferenceCode.equals(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			return "files";
+		}
+
+		return "none";
 	}
 
 	private String _getDateString(Object value) {
 		return _format.format(value);
+	}
+
+	private ObjectEntryFolder _getRootObjectEntryFolder(
+		ObjectEntryFolder objectEntryFolder) {
+
+		if (objectEntryFolder == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) ||
+			Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			return objectEntryFolder;
+		}
+
+		String[] parts = StringUtil.split(
+			objectEntryFolder.getTreePath(), CharPool.SLASH);
+
+		if (parts.length <= 2) {
+			return null;
+		}
+
+		return _objectEntryFolderLocalService.fetchObjectEntryFolder(
+			GetterUtil.getLong(parts[1]));
 	}
 
 	private String _getSortableValue(String value) {
@@ -381,6 +469,7 @@ public class ObjectEntryModelDocumentContributor
 		_accountEntryOrganizationRelLocalService;
 	private final String _className;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectFolderLocalService _objectFolderLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -74,6 +74,7 @@ import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectEntryVersionLocalService;
@@ -982,13 +983,14 @@ public class ObjectDefinitionLocalServiceImpl
 				_assetEntryLocalService, _bundleContext,
 				_dynamicQueryBatchIndexingActionableFactory, _groupLocalService,
 				_listTypeLocalService, _objectActionLocalService,
-				objectDefinitionLocalService, _objectEntryLocalService,
-				_objectEntryService, _objectFieldLocalService,
-				_objectFolderLocalService, _objectLayoutLocalService,
-				_objectLayoutTabLocalService, _objectRelationshipLocalService,
-				_objectScopeProviderRegistry, _objectViewLocalService,
-				_organizationLocalService, _ploEntryLocalService, _portal,
-				_portletLocalService, _resourceActions, _userLocalService,
+				objectDefinitionLocalService, _objectEntryFolderLocalService,
+				_objectEntryLocalService, _objectEntryService,
+				_objectFieldLocalService, _objectFolderLocalService,
+				_objectLayoutLocalService, _objectLayoutTabLocalService,
+				_objectRelationshipLocalService, _objectScopeProviderRegistry,
+				_objectViewLocalService, _organizationLocalService,
+				_ploEntryLocalService, _portal, _portletLocalService,
+				_resourceActions, _userLocalService,
 				_resourcePermissionLocalService, _searchLocalizationHelper,
 				_sharingModelResourcePermissionConfigurator,
 				_workflowDefinitionLinkLocalService,
@@ -3125,6 +3127,9 @@ public class ObjectDefinitionLocalServiceImpl
 	@Reference
 	private ObjectDefinitionSettingLocalService
 		_objectDefinitionSettingLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -7,6 +7,7 @@ package com.liferay.portal.search.rest.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -23,6 +24,7 @@ public class SearchResultEntityModel implements EntityModel {
 
 	public SearchResultEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
 			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(
@@ -64,6 +66,7 @@ public class SearchResultEntityModel implements EntityModel {
 			new IntegerEntityField(
 				"objectDefinitionId", locale -> "objectDefinitionId"),
 			new IntegerEntityField("status", locale -> Field.STATUS),
+			new StringEntityField("cmsKind", locale -> "cms_kind"),
 			new StringEntityField("cmsSection", locale -> "cms_section"),
 			new StringEntityField(
 				"title",

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-view/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-view/page-definition.json
@@ -2,6 +2,20 @@
 	"pageElement": {
 		"id": "e516faca-6284-cfd8-4ce1-33fc578c0da7",
 		"pageElements": [
+			{
+				"definition": {
+					"fragment": {
+						"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewFolderFragmentRenderer"
+					},
+					"fragmentConfig": {
+					},
+					"fragmentFields": [
+					],
+					"indexed": true
+				},
+				"id": "9f8cd286-d294-4662-99d2-d3448993d3ef",
+				"type": "Fragment"
+			}
 		],
 		"type": "Root"
 	},

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/constants/CMSSiteInitializerFDSNames.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/constants/CMSSiteInitializerFDSNames.java
@@ -42,6 +42,9 @@ public class CMSSiteInitializerFDSNames {
 	public static final String STRUCTURES_SECTION =
 		CMSSiteInitializerConstants.BUNDLE_SYMBOLIC_NAME + "-structuresSection";
 
+	public static final String VIEW_FOLDER =
+		CMSSiteInitializerConstants.BUNDLE_SYMBOLIC_NAME + "-viewFolder";
+
 	public static final String VOCABULARIES =
 		CMSSiteInitializerConstants.BUNDLE_SYMBOLIC_NAME + "-vocabularies";
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
@@ -11,7 +11,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -88,7 +87,8 @@ public class AllSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return StringPool.BLANK;
+		return "(cmsSection eq 'contents' or cmsSection eq 'files') and " +
+			"cmsKind eq 'object'";
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
@@ -69,7 +69,13 @@ public class AllSectionDisplayContext extends BaseSectionDisplayContext {
 	}
 
 	@Override
-	public String[] getObjectFolderExternalReferenceCodes() {
+	protected String getCMSSectionFilterString() {
+		return "(cmsSection eq 'contents' or cmsSection eq 'files') and " +
+			"cmsKind eq 'object'";
+	}
+
+	@Override
+	protected String[] getObjectFolderExternalReferenceCodes() {
 		return new String[] {
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
@@ -77,9 +83,8 @@ public class AllSectionDisplayContext extends BaseSectionDisplayContext {
 	}
 
 	@Override
-	protected String getCMSSectionFilterString() {
-		return "(cmsSection eq 'contents' or cmsSection eq 'files') and " +
-			"cmsKind eq 'object'";
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return null;
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
@@ -7,7 +7,6 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
@@ -15,6 +14,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.util.List;
 import java.util.Map;
@@ -31,22 +31,13 @@ public class AllSectionDisplayContext extends BaseSectionDisplayContext {
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService
-			objectDefinitionSettingLocalService) {
+		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
+		Portal portal) {
 
 		super(
 			depotEntryLocalService, groupLocalService, httpServletRequest,
 			language, objectDefinitionService,
-			objectDefinitionSettingLocalService);
-	}
-
-	@Override
-	public CreationMenu getCreationMenu() {
-		return new CreationMenu() {
-			{
-				addStructureContentDropdownItems(this);
-			}
-		};
+			objectDefinitionSettingLocalService, portal);
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -80,31 +80,19 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	public String getAPIURL() {
-		String[] objectFolderExternalReferenceCodes =
-			getObjectFolderExternalReferenceCodes();
+		StringBundler sb = new StringBundler(4);
 
-		StringBundler sb = new StringBundler(10);
-
-		sb.append("/o/search/v1.0/search?emptySearch=true&filter=(");
+		sb.append("/o/search/v1.0/search?emptySearch=true&filter=");
 
 		if (_objectEntryFolder != null) {
-			sb.append("folderId eq");
+			sb.append("folderId eq ");
 			sb.append(_objectEntryFolder.getObjectEntryFolderId());
-			sb.append("and");
+		}
+		else {
+			sb.append(getCMSSectionFilterString());
 		}
 
-		sb.append("(objectFolderExternalReferenceCode in ('");
-		sb.append(StringUtil.merge(objectFolderExternalReferenceCodes, "','"));
-		sb.append("')");
-
-		String cmsSectionFilterString = getCMSSectionFilterString();
-
-		if (Validator.isNotNull(cmsSectionFilterString)) {
-			sb.append(" or ");
-			sb.append(cmsSectionFilterString);
-		}
-
-		sb.append("))&nestedFields=embedded,file.thumbnailURL");
+		sb.append("&nestedFields=embedded,file.thumbnailURL");
 
 		return sb.toString();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -12,6 +12,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -41,6 +43,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.portlet.ActionRequest;
 
@@ -210,7 +213,11 @@ public abstract class BaseSectionDisplayContext {
 							themeDisplay.getPortalURL(),
 							themeDisplay.getPathMain(),
 							GroupConstants.CMS_FRIENDLY_URL,
-							"/add_structured_content_item?objectDefinitionId=",
+							"/add_structured_content_item?",
+							"objectEntryFolderExternalReferenceCode=",
+							_getObjectEntryFolderExternalReferenceCode(
+								objectDefinition),
+							"&objectDefinitionId=",
 							objectDefinition.getObjectDefinitionId(), "&plid=",
 							themeDisplay.getPlid()));
 					dropdownItem.putData(
@@ -306,6 +313,31 @@ public abstract class BaseSectionDisplayContext {
 				StringUtil.split(objectDefinitionSetting.getValue()),
 				groupId -> _depotEntryLocalService.fetchGroupDepotEntry(
 					GetterUtil.getLong(groupId))));
+	}
+
+	private String _getObjectEntryFolderExternalReferenceCode(
+		ObjectDefinition objectDefinition) {
+
+		if (_objectEntryFolder != null) {
+			return _objectEntryFolder.getExternalReferenceCode();
+		}
+
+		if (Objects.equals(
+				objectDefinition.getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
+			return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
+		}
+
+		if (Objects.equals(
+				objectDefinition.getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES)) {
+
+			return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS;
+		}
+
+		return null;
 	}
 
 	private String _getParentObjectEntryFolderExternalReferenceCode() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -170,6 +170,18 @@ public abstract class BaseSectionDisplayContext {
 				).build()),
 			new FDSActionDropdownItem(
 				StringBundler.concat(
+					themeDisplay.getPathFriendlyURLPublic(),
+					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
+					portal.getClassNameId(ObjectEntryFolder.class),
+					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
+				"pencil", "editFolder",
+				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
+				null,
+				HashMapBuilder.<String, Object>put(
+					"entryClassName", ObjectEntryFolder.class.getName()
+				).build()),
+			new FDSActionDropdownItem(
+				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/edit_content_item?objectEntryId={embedded.id}&",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -34,7 +35,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -55,8 +56,8 @@ public abstract class BaseSectionDisplayContext {
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService
-			objectDefinitionSettingLocalService) {
+		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
+		Portal portal) {
 
 		_depotEntryLocalService = depotEntryLocalService;
 		_groupLocalService = groupLocalService;
@@ -74,6 +75,8 @@ public abstract class BaseSectionDisplayContext {
 		_objectEntryFolder =
 			object instanceof ObjectEntryFolder ? (ObjectEntryFolder)object :
 				null;
+
+		this.portal = portal;
 
 		themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -105,7 +108,48 @@ public abstract class BaseSectionDisplayContext {
 				null));
 	}
 
-	public abstract CreationMenu getCreationMenu();
+	public CreationMenu getCreationMenu() {
+		return new CreationMenu() {
+			{
+				String[] objectFolderExternalReferenceCodes =
+					getObjectFolderExternalReferenceCodes();
+
+				if (objectFolderExternalReferenceCodes.length == 2) {
+					addPrimaryDropdownItem(
+						dropdownItem -> {
+							dropdownItem.putData("action", "createFolder");
+							dropdownItem.putData(
+								"assetLibraries",
+								getDepotEntriesJSONArray(
+									_depotEntryLocalService.getDepotEntries(
+										QueryUtil.ALL_POS, QueryUtil.ALL_POS)));
+							dropdownItem.putData(
+								"baseAssetLibraryViewURL",
+								StringBundler.concat(
+									themeDisplay.getPathFriendlyURLPublic(),
+									GroupConstants.CMS_FRIENDLY_URL,
+									"/e/space/",
+									portal.getClassNameId(DepotEntry.class),
+									StringPool.SLASH));
+							dropdownItem.putData(
+								"baseFolderViewURL",
+								StringBundler.concat(
+									themeDisplay.getPathFriendlyURLPublic(),
+									GroupConstants.CMS_FRIENDLY_URL,
+									"/e/view-folder/",
+									portal.getClassNameId(
+										ObjectEntryFolder.class),
+									StringPool.SLASH));
+							dropdownItem.setIcon("folder");
+							dropdownItem.setLabel(
+								language.get(httpServletRequest, "folder"));
+						});
+				}
+
+				addStructureContentDropdownItems(this);
+			}
+		};
+	}
 
 	public abstract Map<String, Object> getEmptyState();
 
@@ -121,7 +165,7 @@ public abstract class BaseSectionDisplayContext {
 				"get", "update", null),
 			new FDSActionDropdownItem(
 				PortletURLBuilder.create(
-					PortalUtil.getControlPanelPortletURL(
+					portal.getControlPanelPortletURL(
 						httpServletRequest,
 						"com_liferay_portlet_configuration_web_portlet_" +
 							"PortletConfigurationPortlet",
@@ -210,6 +254,7 @@ public abstract class BaseSectionDisplayContext {
 
 	protected final HttpServletRequest httpServletRequest;
 	protected final Language language;
+	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
 
 	private JSONArray _getDepotEntriesJSONArray(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -111,10 +111,7 @@ public abstract class BaseSectionDisplayContext {
 	public CreationMenu getCreationMenu() {
 		return new CreationMenu() {
 			{
-				String[] objectFolderExternalReferenceCodes =
-					getObjectFolderExternalReferenceCodes();
-
-				if (objectFolderExternalReferenceCodes.length == 2) {
+				if (getRootObjectEntryFolderExternalReferenceCode() != null) {
 					addPrimaryDropdownItem(
 						dropdownItem -> {
 							dropdownItem.putData("action", "createFolder");
@@ -251,6 +248,8 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	protected abstract String[] getObjectFolderExternalReferenceCodes();
+
+	protected abstract String getRootObjectEntryFolderExternalReferenceCode();
 
 	protected final HttpServletRequest httpServletRequest;
 	protected final Language language;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -116,10 +116,7 @@ public abstract class BaseSectionDisplayContext {
 						dropdownItem -> {
 							dropdownItem.putData("action", "createFolder");
 							dropdownItem.putData(
-								"assetLibraries",
-								getDepotEntriesJSONArray(
-									_depotEntryLocalService.getDepotEntries(
-										QueryUtil.ALL_POS, QueryUtil.ALL_POS)));
+								"assetLibraries", _getDepotEntriesJSONArray());
 							dropdownItem.putData(
 								"baseAssetLibraryViewURL",
 								StringBundler.concat(
@@ -137,6 +134,9 @@ public abstract class BaseSectionDisplayContext {
 									portal.getClassNameId(
 										ObjectEntryFolder.class),
 									StringPool.SLASH));
+							dropdownItem.putData(
+								"parentObjectEntryFolderExternalReferenceCode",
+								_getParentObjectEntryFolderExternalReferenceCode());
 							dropdownItem.setIcon("folder");
 							dropdownItem.setLabel(
 								language.get(httpServletRequest, "folder"));
@@ -256,6 +256,24 @@ public abstract class BaseSectionDisplayContext {
 	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
 
+	private JSONArray _getDepotEntriesJSONArray() {
+		if (_objectEntryFolder == null) {
+			return getDepotEntriesJSONArray(
+				_depotEntryLocalService.getDepotEntries(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+		}
+
+		Group group = _groupLocalService.fetchGroup(
+			_objectEntryFolder.getGroupId());
+
+		return JSONUtil.putAll(
+			JSONUtil.put(
+				"groupId", group.getGroupId()
+			).put(
+				"name", group.getName(themeDisplay.getLocale())
+			));
+	}
+
 	private JSONArray _getDepotEntriesJSONArray(
 		ObjectDefinition objectDefinition) {
 
@@ -288,6 +306,14 @@ public abstract class BaseSectionDisplayContext {
 				StringUtil.split(objectDefinitionSetting.getValue()),
 				groupId -> _depotEntryLocalService.fetchGroupDepotEntry(
 					GetterUtil.getLong(groupId))));
+	}
+
+	private String _getParentObjectEntryFolderExternalReferenceCode() {
+		if (_objectEntryFolder == null) {
+			return getRootObjectEntryFolderExternalReferenceCode();
+		}
+
+		return _objectEntryFolder.getExternalReferenceCode();
 	}
 
 	private final DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -155,6 +156,18 @@ public abstract class BaseSectionDisplayContext {
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
 		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					themeDisplay.getPathFriendlyURLPublic(),
+					GroupConstants.CMS_FRIENDLY_URL, "/e/view-folder/",
+					portal.getClassNameId(ObjectEntryFolder.class),
+					"/{embedded.id}"),
+				"pencil", "view",
+				LanguageUtil.get(httpServletRequest, "view-folder"), "get",
+				"update", null,
+				HashMapBuilder.<String, Object>put(
+					"entryClassName", ObjectEntryFolder.class.getName()
+				).build()),
 			new FDSActionDropdownItem(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -5,18 +5,14 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -45,10 +41,7 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 		super(
 			depotEntryLocalService, groupLocalService, httpServletRequest,
 			language, objectDefinitionService,
-			objectDefinitionSettingLocalService);
-
-		_depotEntryLocalService = depotEntryLocalService;
-		_portal = portal;
+			objectDefinitionSettingLocalService, portal);
 	}
 
 	public Map<String, Object> getAdditionalProps() {
@@ -56,43 +49,6 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 			"parentObjectEntryFolderExternalReferenceCode",
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS
 		).build();
-	}
-
-	@Override
-	public CreationMenu getCreationMenu() {
-		return new CreationMenu() {
-			{
-				addPrimaryDropdownItem(
-					dropdownItem -> {
-						dropdownItem.putData("action", "createFolder");
-						dropdownItem.putData(
-							"assetLibraries",
-							getDepotEntriesJSONArray(
-								_depotEntryLocalService.getDepotEntries(
-									QueryUtil.ALL_POS, QueryUtil.ALL_POS)));
-						dropdownItem.putData(
-							"baseAssetLibraryViewURL",
-							StringBundler.concat(
-								themeDisplay.getPathFriendlyURLPublic(),
-								GroupConstants.CMS_FRIENDLY_URL, "/e/space/",
-								_portal.getClassNameId(DepotEntry.class),
-								StringPool.SLASH));
-						dropdownItem.putData(
-							"baseFolderViewURL",
-							StringBundler.concat(
-								themeDisplay.getPathFriendlyURLPublic(),
-								GroupConstants.CMS_FRIENDLY_URL,
-								"/e/view-folder/",
-								_portal.getClassNameId(ObjectEntryFolder.class),
-								StringPool.SLASH));
-						dropdownItem.setIcon("folder");
-						dropdownItem.setLabel(
-							language.get(httpServletRequest, "folder"));
-					});
-
-				addStructureContentDropdownItems(this);
-			}
-		};
 	}
 
 	@Override
@@ -120,7 +76,7 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 				StringBundler.concat(
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
-					_portal.getClassNameId(ObjectEntryFolder.class),
+					portal.getClassNameId(ObjectEntryFolder.class),
 					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
 				"pencil", "editFolder",
 				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
@@ -140,8 +96,5 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 	protected String getCMSSectionFilterString() {
 		return "cmsSection eq 'contents' and cmsRoot eq true";
 	}
-
-	private final DepotEntryLocalService _depotEntryLocalService;
-	private final Portal _portal;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -138,7 +138,7 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return "cmsSection eq 'contents'";
+		return "cmsSection eq 'contents' and cmsRoot eq true";
 	}
 
 	private final DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -44,13 +44,6 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 			objectDefinitionSettingLocalService, portal);
 	}
 
-	public Map<String, Object> getAdditionalProps() {
-		return HashMapBuilder.<String, Object>put(
-			"parentObjectEntryFolderExternalReferenceCode",
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS
-		).build();
-	}
-
 	@Override
 	public Map<String, Object> getEmptyState() {
 		return HashMapBuilder.<String, Object>put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -86,15 +86,20 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 	}
 
 	@Override
-	public String[] getObjectFolderExternalReferenceCodes() {
+	protected String getCMSSectionFilterString() {
+		return "cmsSection eq 'contents' and cmsRoot eq true";
+	}
+
+	@Override
+	protected String[] getObjectFolderExternalReferenceCodes() {
 		return new String[] {
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES
 		};
 	}
 
 	@Override
-	protected String getCMSSectionFilterString() {
-		return "cmsSection eq 'contents' and cmsRoot eq true";
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS;
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -6,21 +6,15 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -56,26 +50,6 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 		).put(
 			"title", language.get(httpServletRequest, "no-content-yet")
 		).build();
-	}
-
-	@Override
-	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			super.getFDSActionDropdownItems();
-
-		fdsActionDropdownItems.add(
-			1,
-			new FDSActionDropdownItem(
-				StringBundler.concat(
-					themeDisplay.getPathFriendlyURLPublic(),
-					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
-					portal.getClassNameId(ObjectEntryFolder.class),
-					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
-				"pencil", "editFolder",
-				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
-				null));
-
-		return fdsActionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -143,7 +143,7 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return "cmsSection eq 'files'";
+		return "cmsSection eq 'files' and cmsRoot eq true";
 	}
 
 	private final DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -44,13 +44,6 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 			objectDefinitionSettingLocalService, portal);
 	}
 
-	public Map<String, Object> getAdditionalProps() {
-		return HashMapBuilder.<String, Object>put(
-			"parentObjectEntryFolderExternalReferenceCode",
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES
-		).build();
-	}
-
 	@Override
 	public Map<String, Object> getEmptyState() {
 		return HashMapBuilder.<String, Object>put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -9,13 +9,10 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -64,17 +61,6 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 
 		fdsActionDropdownItems.add(
 			1,
-			new FDSActionDropdownItem(
-				StringBundler.concat(
-					themeDisplay.getPathFriendlyURLPublic(),
-					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
-					portal.getClassNameId(ObjectEntryFolder.class),
-					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
-				"pencil", "editFolder",
-				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
-				null));
-		fdsActionDropdownItems.add(
-			2,
 			new FDSActionDropdownItem(
 				"{embedded.file.link.href}", "download", "download",
 				LanguageUtil.get(httpServletRequest, "download"), "get", null,

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -91,15 +91,20 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 	}
 
 	@Override
-	public String[] getObjectFolderExternalReferenceCodes() {
+	protected String getCMSSectionFilterString() {
+		return "cmsSection eq 'files' and cmsRoot eq true";
+	}
+
+	@Override
+	protected String[] getObjectFolderExternalReferenceCodes() {
 		return new String[] {
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
 		};
 	}
 
 	@Override
-	protected String getCMSSectionFilterString() {
-		return "cmsSection eq 'files' and cmsRoot eq true";
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -5,18 +5,14 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -45,10 +41,7 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 		super(
 			depotEntryLocalService, groupLocalService, httpServletRequest,
 			language, objectDefinitionService,
-			objectDefinitionSettingLocalService);
-
-		_depotEntryLocalService = depotEntryLocalService;
-		_portal = portal;
+			objectDefinitionSettingLocalService, portal);
 	}
 
 	public Map<String, Object> getAdditionalProps() {
@@ -56,43 +49,6 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 			"parentObjectEntryFolderExternalReferenceCode",
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES
 		).build();
-	}
-
-	@Override
-	public CreationMenu getCreationMenu() {
-		return new CreationMenu() {
-			{
-				addPrimaryDropdownItem(
-					dropdownItem -> {
-						dropdownItem.putData("action", "createFolder");
-						dropdownItem.putData(
-							"assetLibraries",
-							getDepotEntriesJSONArray(
-								_depotEntryLocalService.getDepotEntries(
-									QueryUtil.ALL_POS, QueryUtil.ALL_POS)));
-						dropdownItem.putData(
-							"baseAssetLibraryViewURL",
-							StringBundler.concat(
-								themeDisplay.getPathFriendlyURLPublic(),
-								GroupConstants.CMS_FRIENDLY_URL, "/e/space/",
-								_portal.getClassNameId(DepotEntry.class),
-								StringPool.SLASH));
-						dropdownItem.putData(
-							"baseFolderViewURL",
-							StringBundler.concat(
-								themeDisplay.getPathFriendlyURLPublic(),
-								GroupConstants.CMS_FRIENDLY_URL,
-								"/e/view-folder/",
-								_portal.getClassNameId(ObjectEntryFolder.class),
-								StringPool.SLASH));
-						dropdownItem.setIcon("folder");
-						dropdownItem.setLabel(
-							language.get(httpServletRequest, "folder"));
-					});
-
-				addStructureContentDropdownItems(this);
-			}
-		};
 	}
 
 	@Override
@@ -119,7 +75,7 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 				StringBundler.concat(
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
-					_portal.getClassNameId(ObjectEntryFolder.class),
+					portal.getClassNameId(ObjectEntryFolder.class),
 					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
 				"pencil", "editFolder",
 				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
@@ -145,8 +101,5 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 	protected String getCMSSectionFilterString() {
 		return "cmsSection eq 'files' and cmsRoot eq true";
 	}
-
-	private final DepotEntryLocalService _depotEntryLocalService;
-	private final Portal _portal;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderDisplayContext.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.info.constants.InfoDisplayWebKeys;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class ViewFolderDisplayContext extends BaseSectionDisplayContext {
+
+	public ViewFolderDisplayContext(
+		DepotEntryLocalService depotEntryLocalService,
+		GroupLocalService groupLocalService,
+		HttpServletRequest httpServletRequest, Language language,
+		ObjectDefinitionService objectDefinitionService,
+		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
+		ObjectEntryFolderLocalService objectEntryFolderLocalService,
+		Portal portal) {
+
+		super(
+			depotEntryLocalService, groupLocalService, httpServletRequest,
+			language, objectDefinitionService,
+			objectDefinitionSettingLocalService, portal);
+
+		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+	}
+
+	@Override
+	public Map<String, Object> getEmptyState() {
+		String rootObjectEntryFolderExternalReferenceCode =
+			getRootObjectEntryFolderExternalReferenceCode();
+
+		String description = "click-new-to-create-your-first-asset";
+		String image = "/states/cms_empty_state.svg";
+		String title = "no-assets-yet";
+
+		if (Objects.equals(
+				rootObjectEntryFolderExternalReferenceCode,
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
+
+			description = "click-new-to-create-your-first-file";
+			image = "/states/cms_empty_state_content.svg";
+			title = "no-content-yet";
+		}
+		else if (Objects.equals(
+					rootObjectEntryFolderExternalReferenceCode,
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			description = "click-new-to-create-your-first-piece-of-content";
+			image = "/states/cms_empty_state_files.svg";
+			title = "no-files-yet";
+		}
+
+		return HashMapBuilder.<String, Object>put(
+			"description", LanguageUtil.get(httpServletRequest, description)
+		).put(
+			"image", image
+		).put(
+			"title", LanguageUtil.get(httpServletRequest, title)
+		).build();
+	}
+
+	@Override
+	public String[] getObjectFolderExternalReferenceCodes() {
+		if (_objectFolderExternalReferenceCode != null) {
+			return new String[] {_objectFolderExternalReferenceCode};
+		}
+
+		String rootObjectEntryFolderExternalReferenceCode =
+			getRootObjectEntryFolderExternalReferenceCode();
+
+		if (rootObjectEntryFolderExternalReferenceCode == null) {
+			return new String[0];
+		}
+
+		if (rootObjectEntryFolderExternalReferenceCode.equals(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
+
+			_objectFolderExternalReferenceCode =
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+		}
+
+		if (rootObjectEntryFolderExternalReferenceCode.equals(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			_objectFolderExternalReferenceCode =
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
+		}
+
+		return new String[] {_objectFolderExternalReferenceCode};
+	}
+
+	@Override
+	public String getRootObjectEntryFolderExternalReferenceCode() {
+		if (_rootObjectEntryFolderExternalReferenceCode != null) {
+			return _rootObjectEntryFolderExternalReferenceCode;
+		}
+
+		Object object = httpServletRequest.getAttribute(
+			InfoDisplayWebKeys.INFO_ITEM);
+
+		ObjectEntryFolder objectEntryFolder =
+			object instanceof ObjectEntryFolder ? (ObjectEntryFolder)object :
+				null;
+
+		if (objectEntryFolder == null) {
+			return null;
+		}
+
+		String[] parts = StringUtil.split(
+			objectEntryFolder.getTreePath(), CharPool.SLASH);
+
+		if (parts.length <= 2) {
+			return null;
+		}
+
+		ObjectEntryFolder rootObjectEntryFolder =
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(
+				GetterUtil.getLong(parts[1]));
+
+		if (rootObjectEntryFolder == null) {
+			return null;
+		}
+
+		_rootObjectEntryFolderExternalReferenceCode =
+			rootObjectEntryFolder.getExternalReferenceCode();
+
+		return _rootObjectEntryFolderExternalReferenceCode;
+	}
+
+	@Override
+	protected String getCMSSectionFilterString() {
+		return null;
+	}
+
+	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+	private String _objectFolderExternalReferenceCode;
+	private String _rootObjectEntryFolderExternalReferenceCode;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AllSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AllSectionFragmentRenderer.java
@@ -12,6 +12,7 @@ import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.AllSectionDisplayContext;
 
 import java.io.IOException;
@@ -58,7 +59,7 @@ public class AllSectionFragmentRenderer extends BaseSectionFragmentRenderer {
 				new AllSectionDisplayContext(
 					_depotEntryLocalService, _groupLocalService,
 					httpServletRequest, _language, _objectDefinitionService,
-					_objectDefinitionSettingLocalService));
+					_objectDefinitionSettingLocalService, _portal));
 
 			requestDispatcher.include(httpServletRequest, httpServletResponse);
 		}
@@ -82,6 +83,9 @@ public class AllSectionFragmentRenderer extends BaseSectionFragmentRenderer {
 	@Reference
 	private ObjectDefinitionSettingLocalService
 		_objectDefinitionSettingLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.site.cms.site.initializer)"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFolderFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFolderFragmentRenderer.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
+
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.site.cms.site.initializer.internal.display.context.ViewFolderDisplayContext;
+
+import java.io.IOException;
+
+import java.util.Locale;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Galluzzi
+ */
+@Component(service = FragmentRenderer.class)
+public class ViewFolderFragmentRenderer extends BaseSectionFragmentRenderer {
+
+	@Override
+	public String getCollectionKey() {
+		return "sections";
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "view-folder");
+	}
+
+	@Override
+	public void render(
+			FragmentRendererContext fragmentRendererContext,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		try {
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher("/view_folder.jsp");
+
+			httpServletRequest.setAttribute(
+				ViewFolderDisplayContext.class.getName(),
+				new ViewFolderDisplayContext(
+					_depotEntryLocalService, _groupLocalService,
+					httpServletRequest, _language, _objectDefinitionService,
+					_objectDefinitionSettingLocalService,
+					_objectEntryFolderLocalService, _portal));
+
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.site.cms.site.initializer)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ContentsSectionTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ContentsSectionTableFDSView.java
@@ -33,8 +33,10 @@ public class ContentsSectionTableFDSView extends BaseTableFDSView {
 
 		return fdsTableSchemaBuilder.add(
 			"embedded.title", "title",
-			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"title"
+			fdsTableSchemaField -> fdsTableSchemaField.setActionId(
+				"view"
+			).setContentRenderer(
+				"actionLink"
 			).setSortable(
 				true
 			)

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/FilesSectionTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/FilesSectionTableFDSView.java
@@ -33,8 +33,10 @@ public class FilesSectionTableFDSView extends BaseTableFDSView {
 
 		return fdsTableSchemaBuilder.add(
 			"embedded.title", "title",
-			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"title"
+			fdsTableSchemaField -> fdsTableSchemaField.setActionId(
+				"view"
+			).setContentRenderer(
+				"actionLink"
 			).setSortable(
 				true
 			)

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/FolderTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/FolderTableFDSView.java
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.view.table;
+
+import com.liferay.frontend.data.set.view.FDSView;
+import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
+import com.liferay.frontend.data.set.view.table.FDSTableSchema;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Galluzzi
+ */
+@Component(
+	property = "frontend.data.set.name=" + CMSSiteInitializerFDSNames.VIEW_FOLDER,
+	service = FDSView.class
+)
+public class FolderTableFDSView extends BaseTableFDSView {
+
+	@Override
+	public FDSTableSchema getFDSTableSchema(Locale locale) {
+		FDSTableSchemaBuilder fdsTableSchemaBuilder =
+			_fdsTableSchemaBuilderFactory.create();
+
+		return fdsTableSchemaBuilder.add(
+			"embedded.title", "title",
+			fdsTableSchemaField -> fdsTableSchemaField.setActionId(
+				"view"
+			).setContentRenderer(
+				"actionLink"
+			).setSortable(
+				true
+			)
+		).add(
+			"embedded.objectDefinitionName", "type",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"typeTableCellRenderer")
+		).add(
+			"embedded.creator.name", "author",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"authorTableCellRenderer")
+		).add(
+			"dateModified", "modified",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"dateTime"
+			).setSortable(
+				true
+			)
+		).add(
+			"embedded.status", "status",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"status")
+		).build();
+	}
+
+	@Reference
+	private FDSTableSchemaBuilderFactory _fdsTableSchemaBuilderFactory;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/AddStructuredContentItemStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/AddStructuredContentItemStrutsAction.java
@@ -8,8 +8,6 @@ package com.liferay.site.cms.site.initializer.internal.struts;
 import com.liferay.fragment.listener.FragmentEntryLinkListenerRegistry;
 import com.liferay.layout.manager.FormManager;
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
@@ -71,19 +69,8 @@ public class AddStructuredContentItemStrutsAction implements StrutsAction {
 		ObjectEntry objectEntry = new ObjectEntry();
 
 		objectEntry.setObjectEntryFolderExternalReferenceCode(
-			() -> {
-				if (Objects.equals(
-						objectDefinition.getObjectFolderExternalReferenceCode(),
-						ObjectFolderConstants.
-							EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
-					return ObjectEntryFolderConstants.
-						EXTERNAL_REFERENCE_CODE_FILES;
-				}
-
-				return ObjectEntryFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENTS;
-			});
+			() -> ParamUtil.getString(
+				httpServletRequest, "objectEntryFolderExternalReferenceCode"));
 		objectEntry.setStatus(
 			() -> new Status() {
 				{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/contents_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/contents_section.jsp
@@ -13,7 +13,6 @@ ContentsSectionDisplayContext contentsSectionDisplayContext = (ContentsSectionDi
 
 <div class="cms-section custom-empty-state">
 	<frontend-data-set:headless-display
-		additionalProps="<%= contentsSectionDisplayContext.getAdditionalProps() %>"
 		apiURL="<%= contentsSectionDisplayContext.getAPIURL() %>"
 		bulkActionDropdownItems="<%= contentsSectionDisplayContext.getBulkActionDropdownItems() %>"
 		creationMenu="<%= contentsSectionDisplayContext.getCreationMenu() %>"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/files_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/files_section.jsp
@@ -13,7 +13,6 @@ FilesSectionDisplayContext filesSectionDisplayContext = (FilesSectionDisplayCont
 
 <div class="cms-section custom-empty-state">
 	<frontend-data-set:headless-display
-		additionalProps="<%= filesSectionDisplayContext.getAdditionalProps() %>"
 		apiURL="<%= filesSectionDisplayContext.getAPIURL() %>"
 		bulkActionDropdownItems="<%= filesSectionDisplayContext.getBulkActionDropdownItems() %>"
 		creationMenu="<%= filesSectionDisplayContext.getCreationMenu() %>"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
@@ -24,6 +24,7 @@ page import="com.liferay.site.cms.site.initializer.internal.display.context.Stru
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewCategoriesDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewCategoryUsagesDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewDashboardDisplayContext" %><%@
+page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewFolderDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewTagsDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewVocabulariesDisplayContext" %>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
@@ -15,6 +15,7 @@ export {default as AllSpacesFDSPropsTransformer} from './main/FDSPropsTransforme
 export {default as CategoryFDSPropsTransformer} from './main/FDSPropsTransformer/CategoryFDSPropsTransformer';
 export {default as ContentsFDSPropsTransformer} from './main/FDSPropsTransformer/ContentsFDSPropsTransformer';
 export {default as FilesFDSPropsTransformer} from './main/FDSPropsTransformer/FilesFDSPropsTransformer';
+export {default as FolderFDSPropsTransformer} from './main/FDSPropsTransformer/FolderFDSPropsTransformer';
 export {default as StructureUsagesFDSPropsTransformer} from './main/FDSPropsTransformer/StructureUsagesFDSPropsTransformer';
 export {default as StructuresFDSPropsTransformer} from './main/FDSPropsTransformer/StructuresFDSPropsTransformer';
 export {default as VocabularyFDSPropsTransformer} from './main/FDSPropsTransformer/VocabularyFDSPropsTransformer';

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/ContentsFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/ContentsFDSPropsTransformer.ts
@@ -22,7 +22,6 @@ const OBJECT_ENTRY_FOLDER_CLASSNAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 
 export default function ContentFDSPropsTransformer({
-	additionalProps,
 	creationMenu,
 	itemsActions = [],
 	...otherProps
@@ -38,8 +37,7 @@ export default function ContentFDSPropsTransformer({
 			...creationMenu,
 			primaryItems: addOnClickToCreationMenuItems(
 				creationMenu.primaryItems,
-				ACTIONS,
-				additionalProps
+				ACTIONS
 			),
 		},
 		customRenderers: {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
@@ -22,7 +22,6 @@ const OBJECT_ENTRY_FOLDER_CLASSNAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 
 export default function FilesFDSPropsTransformer({
-	additionalProps,
 	creationMenu,
 	itemsActions = [],
 	...otherProps
@@ -38,8 +37,7 @@ export default function FilesFDSPropsTransformer({
 			...creationMenu,
 			primaryItems: addOnClickToCreationMenuItems(
 				creationMenu.primaryItems,
-				ACTIONS,
-				additionalProps
+				ACTIONS
 			),
 		},
 		customRenderers: {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FolderFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FolderFDSPropsTransformer.ts
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+
+import createAssetAction from './actions/createAssetAction';
+import createFolderAction from './actions/createFolderAction';
+import AuthorRenderer from './cell_renderers/AuthorRenderer';
+import NameRenderer from './cell_renderers/NameRenderer';
+import TypeRenderer from './cell_renderers/TypeRenderer';
+import addOnClickToCreationMenuItems from './utils/addOnClickToCreationMenuItems';
+
+const ACTIONS = {
+	createAsset: createAssetAction,
+	createFolder: createFolderAction,
+};
+
+const OBJECT_ENTRY_FOLDER_CLASSNAME =
+	'com.liferay.object.model.ObjectEntryFolder';
+
+export default function FolderFDSPropsTransformer({
+	additionalProps,
+	creationMenu,
+	itemsActions = [],
+	...otherProps
+}: {
+	additionalProps: any;
+	creationMenu: any;
+	itemsActions?: any[];
+	otherProps: any;
+}) {
+	return {
+		...otherProps,
+		creationMenu: {
+			...creationMenu,
+			primaryItems: addOnClickToCreationMenuItems(
+				creationMenu.primaryItems,
+				ACTIONS,
+				additionalProps
+			),
+		},
+		customRenderers: {
+			tableCell: [
+				{
+					component: AuthorRenderer,
+					name: 'authorTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: NameRenderer,
+					name: 'nameTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: TypeRenderer,
+					name: 'typeTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+			],
+		},
+		itemsActions: itemsActions.map((action) => {
+			if (action?.data?.id === 'download') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(item?.embedded?.file?.link?.href),
+				};
+			}
+			else if (action?.data?.id === 'edit') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(
+							item?.entryClassName !==
+								OBJECT_ENTRY_FOLDER_CLASSNAME
+						),
+				};
+			}
+			else if (action?.data?.id === 'editFolder') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(
+							item?.entryClassName ===
+								OBJECT_ENTRY_FOLDER_CLASSNAME
+						),
+				};
+			}
+
+			return action;
+		}),
+	};
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createAssetAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createAssetAction.ts
@@ -22,7 +22,7 @@ export default function createAssetAction(data: AssetData) {
 		const url = new URL(data.redirect);
 
 		url.searchParams.set('name', '');
-		url.searchParams.set('groupId', data.assetLibraries[0].groupId);
+		url.searchParams.set('groupId', String(data.assetLibraries[0].groupId));
 
 		navigate(url.pathname + url.search);
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
@@ -16,11 +16,11 @@ export type FolderData = {
 	assetLibraries: AssetLibrary[];
 	baseAssetLibraryViewURL: string;
 	baseFolderViewURL: string;
+	parentObjectEntryFolderExternalReferenceCode: string;
 };
 
 export default function createFolderAction(
 	data: FolderData,
-	additionalProps: {parentObjectEntryFolderExternalReferenceCode: string},
 	loadData?: () => {}
 ) {
 	openModal({
@@ -37,8 +37,8 @@ export default function createFolderAction(
 							title: string;
 						}>(
 							groupId,
-							title,
-							additionalProps.parentObjectEntryFolderExternalReferenceCode
+							data.parentObjectEntryFolderExternalReferenceCode,
+							title
 						);
 
 					if (!error) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/utils/addOnClickToCreationMenuItems.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/utils/addOnClickToCreationMenuItems.ts
@@ -8,8 +8,7 @@ export default function addOnClickToCreationMenuItems(
 	actions: Record<
 		string,
 		(data: any, additionalProps?: any, loadData?: () => {}) => void
-	>,
-	additionalProps?: any
+	>
 ) {
 	return items.map((item: {data?: {action?: string}}) => {
 		return {
@@ -18,7 +17,7 @@ export default function addOnClickToCreationMenuItems(
 				const action = item?.data?.action;
 
 				if (action) {
-					actions[action](item.data, additionalProps, loadData);
+					actions[action](item.data, loadData);
 				}
 			},
 		};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent.tsx
@@ -16,7 +16,7 @@ import {FieldPicker, FieldText} from '../forms';
 import {required, validate} from '../forms/validations';
 
 export type AssetLibrary = {
-	groupId: string;
+	groupId: number;
 	name: string;
 };
 
@@ -26,11 +26,11 @@ type Props = {
 	closeModal: () => void;
 	onSubmit?: (
 		values: {
-			groupId: string;
+			groupId: number;
 			name: string;
 		},
 		formikHelpers: FormikHelpers<{
-			groupId: string;
+			groupId: number;
 			name: string;
 		}>
 	) => Promise<any> | void;
@@ -57,7 +57,7 @@ export default function CreationModalContent({
 	} = useFormik({
 		initialValues: {
 			groupId:
-				assetLibraries.length === 1 ? assetLibraries[0].groupId : '',
+				assetLibraries.length === 1 ? assetLibraries[0].groupId : 0,
 			name: '',
 		},
 		onSubmit: async (values, formikHelpers) => {
@@ -67,7 +67,7 @@ export default function CreationModalContent({
 				const url = new URL(redirect);
 
 				url.searchParams.set('name', name);
-				url.searchParams.set('groupId', groupId);
+				url.searchParams.set('groupId', String(groupId));
 
 				navigate(url.pathname + url.search);
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/FolderService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/FolderService.ts
@@ -16,12 +16,12 @@ export type TFolder = {
 const OBJECT_ENTRY_FOLDER_URL = '/o/headless-object/v1.0/object-entry-folders';
 
 async function createFolder<DataType = unknown>(
-	scopeKey: string,
-	title: string,
-	parentObjectEntryFolderExternalReferenceCode: string
+	groupId: number,
+	parentObjectEntryFolderExternalReferenceCode: string,
+	title: string
 ) {
 	return await ApiHelper.post<DataType>(
-		`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,
+		`/o/headless-object/v1.0/scopes/${groupId}/object-entry-folders`,
 		{
 			parentObjectEntryFolderExternalReferenceCode,
 			title,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
@@ -1,0 +1,29 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+ViewFolderDisplayContext viewFolderDisplayContext = (ViewFolderDisplayContext)request.getAttribute(ViewFolderDisplayContext.class.getName());
+%>
+
+<div class="cms-section">
+	<frontend-data-set:headless-display
+		apiURL="<%= viewFolderDisplayContext.getAPIURL() %>"
+		bulkActionDropdownItems="<%= viewFolderDisplayContext.getBulkActionDropdownItems() %>"
+		creationMenu="<%= viewFolderDisplayContext.getCreationMenu() %>"
+		emptyState="<%= viewFolderDisplayContext.getEmptyState() %>"
+		fdsActionDropdownItems="<%= viewFolderDisplayContext.getFDSActionDropdownItems() %>"
+		formName="fm"
+		id="<%= CMSSiteInitializerFDSNames.VIEW_FOLDER %>"
+		itemsPerPage="<%= 20 %>"
+		propsTransformer="{FolderFDSPropsTransformer} from site-cms-site-initializer"
+		selectedItemsKey="id"
+		selectionType="multiple"
+		style="fluid"
+	/>
+</div>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54424

This is a rebase on top of Marco's PR (rebased on top of current master).

The following needs to be completed:
1. Add the card view as in other FDS fragments.
2. Allow both to view content and navigate into a folder.

Send that as a standalone PR; after that, work on removing all duplication ([LPD-56214](https://liferay.atlassian.net/browse/LPD-56214)). In the end, we should have a single fragment for viewing a folder, and it should be reused in the three sections (ideally, any parametrization -- like root folder, filters, etc. --  should be provided as fragment properties).